### PR TITLE
fixed switching

### DIFF
--- a/accessories/HomeeAccessory.js
+++ b/accessories/HomeeAccessory.js
@@ -35,12 +35,16 @@ HomeeAccessory.prototype.updateValue = function (attribute) {
     if (that.service && attribute.id in that.map) {
 
         let attributeType = attributeTypes.find(x => x.id === attribute.type).hap_type;
-        let value = attribute.current_value;
+        let newValue = attribute.current_value;
+        let oldValue = that.service.getCharacteristic(that.map[attribute.id]).value;
+        let targetValue = attribute.target_value;
 
-        that.service.getCharacteristic(that.map[attribute.id])
-        .updateValue(value, null, 'ws');
+        if(newValue!==oldValue && newValue===targetValue) {
+            that.service.getCharacteristic(that.map[attribute.id])
+            .updateValue(newValue, null, 'ws');
 
-        that.log(that.name + ': ' + attributeType + ': ' + value);
+            that.log(that.name + ': ' + attributeType + ': ' + newValue);
+        }
     }
 }
 


### PR DESCRIPTION
In der aktuellen Version habe ich das Problem, dass sich beim Schalten in Home der Schalter zunächst ein- dann wieder aus- und wieder einschaltet. Das ist darauf zurück zu führen, dass Homee mit `target_value` arbeitet und somit mehrere Nachrichten pro Schaltvorgang ausgibt.

Ich habe den Code angepasst, sodass eine Statusänderung nur erfolgt, wenn:
1. sich der Wert gegenüber dem alten verändert hat.
2. das Gerät endgültig geschalten hat, d.h. `target_value` gleich `current_value` ist.

Das Flackern des Schalters in der Home App ist nun behoben.