### PR TITLE
Clean up authentication device values

### DIFF
--- a/lib/homee.js
+++ b/lib/homee.js
@@ -30,12 +30,11 @@ Homee.prototype.getAccessToken = function() {
             "Content-Type": "application/x-www-form-urlencoded"
         },
         form: {
-            device_name: "iPhone",
-            device_hardware_id: "rrr",
-            device_os: 2,
-            device_type: 1,
-            device_app: 1,
-            device_push_registration_id: 1284
+            device_name: "homebridge",
+            device_hardware_id: "homebridge",
+            device_os: 5, // Linux
+            device_type: 3, // Desktop
+            device_app: 1 // homee
         },
         auth: {
             user: this.user,


### PR DESCRIPTION
`device_os: 2` was android, so homee wanted to send push notifications to homebridge. The rest doesn't really matter for homebridge – but now it fits a little bit more.  