### PR TITLE
fixed destructuring in filterDevices

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ HomeePlatform.prototype.filterDevices = function (all) {
         }
     }
 
-    if(!groupId) return {nodes: all.nodes, homeegrams: all.homeegrams};
+    if(!groupId) return [all.nodes, all.homeegrams];
 
     for (let relationship of all.relationships) {
         if (relationship.group_id === groupId) {


### PR DESCRIPTION
Hi,

die hier beschriebenen Probleme (https://community.hom.ee/t/erstellung-eines-homebridge-plugins-fuer-homekit/862/125) hängen mit dem Destructuring der Ausgabe von `filterDevices` zusammen. Hier wird ein Objekt auf ein Array gemappt. Ich glaube, dass das in ES6 nicht vorgesehen ist, zumindest haben manche NodeJS Versionen ihre Probleme damit.