### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ class HomeePlatform {
         this.attempts = 0;
         this.connected = false;
 
+        if (config.selectGroup === undefined) {
+            this.selectGroup = new RegExp('^homebridge$', 'i');
+        } else {
+            this.selectGroup = new RegExp('^' + config.selectGroup + '$', 'i');
+        }
         if (api) this.api = api;
 
         this.homee.on('message', message => this.handleMessage(message));
@@ -124,7 +129,7 @@ class HomeePlatform {
         let filtered = {nodes: [], homeegrams: []};
 
         for (let group of all.groups) {
-            if (group.name.match(/^homebridge$/i)) {
+            if (group.name.match(this.selectGroup)) {
                 groupId = group.id;
             }
         }


### PR DESCRIPTION
Hinzugefügt: Möglichkeit, in der config-Datei die homee-Gruppe zu wählen, die gefiltert werden soll (anstelle des vorgegebenen Namens "Homebridge"). Das dient dazu, bei mehreren parallel laufenden Instanzen von Homebridge für jede Instanz eine andere Gruppe zu verwenden. Hiermit kann bei großen Installationen das 100-Geräte-Limit ausgehebelt werden.