### PR TITLE
Safeguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Example:
                 "host": "192.168.178.1",
                 "user": "your-username",
                 "pass": "your-password",
-                "groupName": "group-name"
+                "groupName": "group-name",
+                "safeGuard": true
             }
         ]
     }
@@ -41,6 +42,9 @@ This plugin integrates all (known) devices to homebridge by default. You can lim
 
 ### Device Limit
 Homekit cannot manage more than 100 devices per bridge. If you have together more than 100 devices and homeegrams, you have to filter some of them with a group.
+
+### Safeguard Mode
+In certain cases, this plugin may not be able to establish a connection to your homee during startup. This could happen if, for instance, your homee is not running during Homebridge startup or if your local network is down. As Homebridge will continue anyway, this usually results in all homee devices being removed from HomeKit, including all scenes and automation. By setting the optional 'safeGuard' option to true (default: false), you can prevent Homebridge from starting up whenever a connection to your homee cannot be established or when the number of homee devices is zero.
 
 ## Tested devices
 - Danfoss Living connect Thermostat
@@ -57,6 +61,7 @@ Homekit cannot manage more than 100 devices per bridge. If you have together mor
 - Fibaro Smoke Sensor 2
 - Fibaro Wall Plug
 - Greenwave Powernode
+- Permundo PSC234ZW
 - Philips Hue White and Color Ambiance
 - Philips Hue White
 - Popp Rauchwarnmelder mit Sirene

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ In certain cases, this plugin may not be able to establish a connection to your 
 - Fibaro Smoke Sensor 2
 - Fibaro Wall Plug
 - Greenwave Powernode
-- Permundo PSC234ZW
 - Philips Hue White and Color Ambiance
 - Philips Hue White
 - Popp Rauchwarnmelder mit Sirene

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ class HomeePlatform {
         this.attempts = 0;
         this.connected = false;
         this.groupName = config.groupName || 'homebridge';
+        this.safeGuard = config.safeGuard || false;
 
         if (api) this.api = api;
 
@@ -60,7 +61,11 @@ class HomeePlatform {
      */
     accessories (callback) {
         if (this.attempts > 5) {
-            this.log.warn("Can't get devices or homeegrams. Please check that homee is online and your config is right")
+            this.log.warn("Can't get devices or homeegrams. Please check that homee is online and your config is right");
+            if (this.safeGuard) {
+                this.log.warn("Safeguard active - aborting Homebridge startup");
+                throw new Error("Safeguard active - aborting Homebridge startup");
+            }
             callback([]);
             return;
         }
@@ -136,7 +141,14 @@ class HomeePlatform {
             }
         }
 
-        if (!groupId) return [all.nodes, all.homeegrams];
+        if (!groupId) {
+            if (this.groupName !== "homebridge" && this.safeGuard) {
+                this.log.warn("Specified group not found. Safeguard active - aborting Homebridge startup");
+                throw new Error("Safeguard active - aborting Homebridge startup");
+            } else {
+                return [all.nodes, all.homeegrams];
+            }
+        }
 
         for (let relationship of all.relationships) {
             if (relationship.group_id === groupId) {


### PR DESCRIPTION
Optional safeguard added (deactivated by default). 

When enabled, Homebridge launch is aborted in case
- a connection to homee cannot be established (e.g. homee or LAN down, network not available yet after reboot) or
- no homee devices are found (e.g. wrong group name, any other malfunction).

This prevents all affected devices from being removed from HomeKit. This happened to me several times and caused a lot of work, including the re-creation of scenes and automations.