### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class HomeePlatform {
      * @param callback
      */
     accessories (callback) {
-        if (this.attempts > 5) {
+        if (this.attempts > 10) {
             throw new Error("Can't get devices or homeegrams. Please check that homee is online and your config is ok");
         }
 


### PR DESCRIPTION
With homee firmware 2.24, five attempts to retrieve devices and/or Homeegrams are not sufficient. Depending on current homee system load, my system needs six to eight attempts with at least 80% of the homebridge (re-)starts.