### PR TITLE
Update fix for double switch

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ class HomeePlatform {
             let attributes = message.node ? message.node.attributes : [message.attribute];
 
             for (let attribute of attributes) {
-                let accessory = this.foundAccessories.find(a => a.nodeId === attribute.node_id);
+                let accessory = this.foundAccessories.find(a => a.nodeId === attribute.node_id && (a.instance === attribute.instance || a.instance === 0));
                 if (accessory) {
                     accessory.updateValue(attribute);
                     this.log.info('Updated accessory %s', accessory.name);

--- a/index.js
+++ b/index.js
@@ -190,7 +190,9 @@ class HomeePlatform {
             let attributes = message.node ? message.node.attributes : [message.attribute];
 
             for (let attribute of attributes) {
-                let accessory = this.foundAccessories.find(a => a.nodeId === attribute.node_id && (a.instance === attribute.instance || a.instance === 0));
+                let node = this.nodes.find(n => n.id === attribute.node_id);
+                let nodeType = node && nodeTypes.getAccessoryTypeByNodeProfile(node.profile);
+                let accessory = this.foundAccessories.find(a => a.nodeId === attribute.node_id && (nodeType !== 'DoubleSwitch' || a.instance === attribute.instance));
                 if (accessory) {
                     accessory.updateValue(attribute);
                     this.log.info('Updated accessory %s', accessory.name);


### PR DESCRIPTION
When using with a Fibaro double switch, I noticed that the second output was not properly updated in Homekit when the physical switch was pressed. The problem was that always the first instance of the switch was updated, but not the second one.