### PR TITLE
Support for RGB color and color temperature controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Example:
                 "groupName": "group-name",
                 "alarmGroup": "AlarmGroupName",
                 "deviceId": "homebridge",
-                "disableRGB" : false,
-                "disableCT" : false,
-                "disableCTforRGB" : false,
-                "disableRGBforDevice" : [
+                "disableRGB" false,
+                "disableCT": false,
+                "disableCTforRGB": false,
+                "disableRGBforDevice": [
                     123,
                     456
                 ],
-                "disableCTforDevice" : [
+                "disableCTforDevice": [
                     666,
                     815,
                     4711
@@ -76,9 +76,9 @@ You can activate a security system. Just create an alarm group in homee and add 
 While this plugin supports "Lightbulb"-type fixtures with RGB color and/or color temperature controls, the color picker within the Home app has some issues with lights implementing both features at the same time. This behaviour is caused neither by homee nor by the plugin but is a flaw of the app itself. Some third-party apps, such as Eve, show no such erratic behaviour.
 
 Some configuration parameters allow you to precisely control the capabilities of some or all RGB or color temperature lights in HomeKit:
-- `"disableRGB" : true` removes the RGB color controls from **all** devices
-- `"disableCT" : true` removes the color temperature controls from **all** devices
-- `"disableCTforRGB" : true` removes the real color temperature controls from all RGB light fixtures. However, "fake" color temperature controls are still available. By using those controls, HomeKit emulates various color temperatures with the RGB LEDs but does not make any of the additional warm and cold white LEDs your fixture may feature.
+- `"disableRGB": true` removes the RGB color controls from *all* devices
+- `"disableCT": true` removes the color temperature controls from *all* devices
+- `"disableCTforRGB": true` removes the real color temperature controls from all RGB light fixtures. However, "fake" color temperature controls are still available. By using those controls, HomeKit emulates various color temperatures with the RGB LEDs but does not make any of the additional warm and cold white LEDs your fixture may feature.
 - By using the `"disableRGBforDevice"` statement, you may remove the RGB color controls from certain devices by adding their node IDs to the list. To find out the node ID of a device, you may open that device in the homee web application and check the browser address bar afterwards: e.g., `https://my.hom.ee/deviceslist/device/id/331` indicates a node ID of 331.
 - Likewise, you may use the `"disableCTforDevice"`statement to disable color temperature controls for specific devices.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,19 @@ Example:
                 "pass": "your-password",
                 "groupName": "group-name",
                 "alarmGroup": "AlarmGroupName",
-                "deviceId": "homebridge"
+                "deviceId": "homebridge",
+                "disableRGB" : false,
+                "disableCT" : false,
+                "disableCTforRGB" : false,
+                "disableRGBforDevice" : [
+                    123,
+                    456
+                ],
+                "disableCTforDevice" : [
+                    666,
+                    815,
+                    4711
+                ]
             }
         ]
     }
@@ -59,6 +71,16 @@ You can activate a security system. Just create an alarm group in homee and add 
  | Sleeping | Night Armed |
  | Away | Stay Armed |
  | Holiday | Away Armed |
+
+## RGB and Color Temperature Light Sources
+While this plugin supports "Lightbulb"-type fixtures with RGB color and/or color temperature controls, the color picker within the Home app has some issues with lights implementing both features at the same time. This behaviour is caused neither by homee nor by the plugin but is a flaw of the app itself. Some third-party apps, such as Eve, show no such erratic behaviour.
+
+Some configuration parameters allow you to precisely control the capabilities of some or all RGB or color temperature lights in HomeKit:
+- `"disableRGB" : true` removes the RGB color controls from **all** devices
+- `"disableCT" : true` removes the color temperature controls from **all** devices
+- `"disableCTforRGB" : true` removes the real color temperature controls from all RGB light fixtures. However, "fake" color temperature controls are still available. By using those controls, HomeKit emulates various color temperatures with the RGB LEDs but does not make any of the additional warm and cold white LEDs your fixture may feature.
+- By using the `"disableRGBforDevice"` statement, you may remove the RGB color controls from certain devices by adding their node IDs to the list. To find out the node ID of a device, you may open that device in the homee web application and check the browser address bar afterwards: e.g., `https://my.hom.ee/deviceslist/device/id/331` indicates a node ID of 331.
+- Likewise, you may use the `"disableCTforDevice"`statement to disable color temperature controls for specific devices.
 
 ## Tested devices
 - Danfoss Living connect Thermostat

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can activate a security system. Just create an alarm group in homee and add 
  | Holiday | Away Armed |
 
 ## RGB and Color Temperature Light Sources
-While this plugin supports "Lightbulb"-type fixtures with RGB color and/or color temperature controls, the color picker within the Home app has some issues with lights implementing both features at the same time. This behaviour is caused neither by homee nor by the plugin but is a flaw of the app itself. Some third-party apps, such as Eve, show no such erratic behaviour.
+While this plugin supports "Lightbulb"-type fixtures with RGB color and/or color temperature controls, the color picker within the genuine Home app has some issues with lights implementing both features at the same time. This behaviour is caused neither by homee nor by the plugin but is a flaw of the app itself. Some third-party apps, such as Eve, show no such erratic behaviour.
 
 Some configuration parameters allow you to precisely control the capabilities of some or all RGB or color temperature lights in HomeKit:
 - `"disableRGB": true` removes the RGB color controls from *all* devices

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Example:
                 "groupName": "group-name",
                 "alarmGroup": "AlarmGroupName",
                 "deviceId": "homebridge",
-                "disableRGB" false,
-                "disableCT": false,
-                "disableCTforRGB": false,
-                "disableRGBforDevice": [
+                "disableRGB" : false,
+                "disableCT" : false,
+                "disableCTforRGB" : false,
+                "disableRGBforDevice" : [
                     123,
                     456
                 ],
-                "disableCTforDevice": [
+                "disableCTforDevice" : [
                     666,
                     815,
                     4711
@@ -73,12 +73,10 @@ You can activate a security system. Just create an alarm group in homee and add 
  | Holiday | Away Armed |
 
 ## RGB and Color Temperature Light Sources
-While this plugin supports "Lightbulb"-type fixtures with RGB color and/or color temperature controls, the color picker within the genuine Home app has some issues with lights implementing both features at the same time. This behaviour is caused neither by homee nor by the plugin but is a flaw of the app itself. Some third-party apps, such as Eve, show no such erratic behaviour.
-
 Some configuration parameters allow you to precisely control the capabilities of some or all RGB or color temperature lights in HomeKit:
-- `"disableRGB": true` removes the RGB color controls from *all* devices
-- `"disableCT": true` removes the color temperature controls from *all* devices
-- `"disableCTforRGB": true` removes the real color temperature controls from all RGB light fixtures. However, "fake" color temperature controls are still available. By using those controls, HomeKit emulates various color temperatures with the RGB LEDs but does not make any of the additional warm and cold white LEDs your fixture may feature.
+- `"disableRGB" : true` removes the RGB color controls from **all** devices
+- `"disableCT" : true` removes the color temperature controls from **all** devices
+- `"disableCTforRGB" : true` removes the real color temperature controls from all RGB light fixtures. However, "fake" color temperature controls are still available. By using those controls, HomeKit emulates various color temperatures with the RGB LEDs but does not make any of the additional warm and cold white LEDs your fixture may feature.
 - By using the `"disableRGBforDevice"` statement, you may remove the RGB color controls from certain devices by adding their node IDs to the list. To find out the node ID of a device, you may open that device in the homee web application and check the browser address bar afterwards: e.g., `https://my.hom.ee/deviceslist/device/id/331` indicates a node ID of 331.
 - Likewise, you may use the `"disableCTforDevice"`statement to disable color temperature controls for specific devices.
 

--- a/accessories/HomeeAccessory.js
+++ b/accessories/HomeeAccessory.js
@@ -196,8 +196,8 @@ class HomeeAccessory {
 
     // Workaround for HomeKit color picker (does not adjust to color temperature by itself but requires extrenal setting to corresponding color)
     emulateColorTemperature(value, attributeIdHue, attributeIdSaturation) {
-	// Abort if this lightbulb has no hue/saturation characteristics
-	if (this.disableRGB) return;
+	    // Abort if this lightbulb has no hue/saturation characteristics
+	    if (this.disableRGB) return;
 
         let rgb = [];
         let colorTemperature = value;

--- a/accessories/HomeeAccessory.js
+++ b/accessories/HomeeAccessory.js
@@ -14,9 +14,18 @@ class HomeeAccessory {
         this.instance = instance || 0;
         this.attributes = node.attributes;
         this.map = [];
+        if (profile == 'Lightbulb') {
+            // provisions to cache HSB values for color lightbulbs as only one value is provided at a time by HomeKit
+            this.hue = 0;            // will be updated with actual value right after service creation 
+            this.saturation = 0;     // will be updated with actuel value right after service creation
+            this.brightness = 100;   // brightness value currently fixed to 100% for color conversion as setting ignored by homee anyway (except for "dark" color names)
+            this.disableRGB = this.platform.disableRGB || this.platform.disableRGBforDevice.indexOf(this.nodeId) >= 0;
+            this.disableCT = this.platform.disableCT || this.platform.disableCTforDevice.indexOf(this.nodeId) >= 0;
+        }
     }
 
-    setValue(value, callback, context, uuid, attributeId) {
+    setValue(value, callback, context, uuid, attributeId, attributeType) {
+
         if (context && context == 'ws') {
             callback(null, value);
             return;
@@ -25,8 +34,28 @@ class HomeeAccessory {
         if (value === true) value = 1;
         if (value === false) value = 0;
 
-        this.log.debug('Setting ' + this.name + ' to ' + value);
-        this.homee.setValue(this.nodeId, attributeId, value);
+        // color temperature conversion HomeKit [MK-1] -> homee [K]
+        if (attributeType == 42) {
+            value = Math.min(Math.round(1000000 / value), 6535);
+        }
+
+        // special handling for hue/saturation values (provided only one at a time)
+        if (attributeType == 23) {
+            if (attributeId >= 100000) {
+                this.saturation = value;
+            } else {
+                this.hue = value;
+            }
+            value = HSBToColor(this.hue, this.saturation, this.brightness);   // conversion from updated & cachec HSB values to single RGB color value
+        }
+
+        // brightness value currently fixed to 100% for color conversion as setting ignored by homee anyway (except for "dark" color names)
+        // if (attributeType == 2 || attributeType == 61) this.brightness = value;
+
+        if (attributeId < 100000) {   // do not send data to homee when saturation has been updated by HomeKit (virtual attribute ID only, no direct link), this will be done when hue change is repoirted by HomeKit
+            this.log.debug('Setting ' + this.name + ' to ' + value);
+            this.homee.setValue(this.nodeId, attributeId, value);
+        }
 
         callback(null, value);
     }
@@ -38,9 +67,45 @@ class HomeeAccessory {
             let oldValue = this.service.getCharacteristic(this.map[attribute.id]).value;
             let targetValue = attribute.target_value;
 
-            if (newValue !== oldValue && newValue === targetValue) {
-                this.service.getCharacteristic(this.map[attribute.id]).updateValue(newValue, null, 'ws');
-                this.log.debug(this.name + ': ' + attributeType + ': ' + newValue);
+            // color temperature conversion homee [K] -> HomeKit [MK-1]
+            if (attribute.type == 42) {
+                newValue = Math.round(1000000 / newValue);
+                targetValue = Math.round(1000000 / targetValue);
+            }
+
+            // special handling for color lightbulbs as single color value from homee must be split and sent to HomeKit as separate hue/saturation values
+            if (attribute.type == 23) {
+                let attributeIdHue = attribute.id;
+                let attributeIdSaturation = 100000 + attribute.id;   // calculating virtual attribute ID for saturation
+                let newHSB = colorToHSB(newValue);   // conversion from single RGB color value to array containing separate HSB values
+                let oldHue = oldValue;
+                let oldSaturation = this.service.getCharacteristic(this.map[attributeIdSaturation]).value;
+                let targetHSB = colorToHSB(targetValue);   // conversion from single RGB color value to array containing separate HSB values
+            
+                // sending hue value to HomeKit
+                if (newHSB[0] !== oldHue && newHSB[0] === targetHSB[0]) {
+                    this.service.getCharacteristic(this.map[attributeIdHue]).updateValue(newHSB[0], null, 'ws');
+                    this.hue = newHSB[0];
+                    this.log.debug(this.name + ': ' + attributeType + ' (Hue): ' + newHSB[0]);
+                }
+
+                // sending saturation value to HomeKit
+                if (newHSB[1] !== oldSaturation && newHSB[1] === targetHSB[1]) {
+                    this.service.getCharacteristic(this.map[attributeIdSaturation]).updateValue(newHSB[1], null, 'ws');
+                    this.saturation = newHSB[1];
+                    this.log.debug(this.name + ': ' + attributeType + ' (Saturation): ' + newHSB[1]);
+                }
+
+            // handling for all other accessory types
+            } else {
+                if (newValue !== oldValue && newValue === targetValue) {
+                    this.service.getCharacteristic(this.map[attribute.id]).updateValue(newValue, null, 'ws');
+                    /* brightness value currently fixed to 100% for color conversion as setting ignored by homee anyway (except for "dark" color names)
+                    if (attributeType == 'Brightness') {
+                        this.brightness = newValue;
+                    } */
+                    this.log.debug(this.name + ': ' + attributeType + ': ' + newValue);
+                }
             }
         }
     }
@@ -59,32 +124,87 @@ class HomeeAccessory {
         for (let attribute of this.attributes) {
             let attributeType = attributeTypes.getHAPTypeByAttributeType(attribute.type);
             let attributeId = attribute.id;
-
-            // skip characteristic if instance doesn't match
+            
+	    // skip characteristic if instance doesn't match
             if (attributeType === 'On' && this.instance !== 0 && attribute.instance !== this.instance) continue;
 
             // ensure that characteristic 'On' is unique --> Fibaro FGS 213
             if (attributeType === 'On' && this.map.indexOf(Characteristic.On) > -1) continue;
 
+            // skip attribute addition in case the color or color temperature controls are not desired
+            if (attributeType == 'Color' && this.disableRGB) continue;
+            if (attributeType == 'ColorTemperature' && this.disableCT) continue;
+
             if (attributeType) {
                 this.log.debug(attributeType + ': ' + attribute.current_value);
-                this.map[attribute.id] = Characteristic[attributeType];
 
-                if (!this.service.getCharacteristic(Characteristic[attributeType])) {
-                    this.service.addCharacteristic(Characteristic[attributeType]);
-                }
+                // special handling for color lightbulbs as single color value from homee must be split and sent to HomeKit as separate hue/saturation values
+                if (attributeType == 'Color') {
+                    // prevent subsequent addition of color temperature in case this is not desired for color lightbulbs
+                    this.disableCT = this.disableCT || this.platform.disableCTforRGB;
 
-                this.service.getCharacteristic(Characteristic[attributeType]).updateValue(attribute.current_value);
+                    // hue section (using real attribute ID)
+                    attributeType = 'Hue';
+                    this.map[attribute.id] = Characteristic[attributeType];
 
-                if (attribute.editable) {
-                    this.service.getCharacteristic(Characteristic[attributeType]).on(
-                        'set',
-                        function() {
-                            var args = Array.prototype.slice.call(arguments);
-                            args.push(attributeId);
-                            this.setValue.apply(this, args);
-                        }.bind(this)
-                    );
+                    if (!this.service.getCharacteristic(Characteristic[attributeType])) {
+                        this.service.addCharacteristic(Characteristic[attributeType]);
+                    }
+
+                    this.service.getCharacteristic(Characteristic[attributeType]).updateValue(attribute.current_value);
+
+                    if (attribute.editable) {
+                        this.service.getCharacteristic(Characteristic[attributeType]).on(
+                            'set',
+                            function() {
+                                var args = Array.prototype.slice.call(arguments);
+                                args.push(attributeId, attribute.type);
+                                this.setValue.apply(this, args);
+                            }.bind(this)
+                        );
+                    }
+
+                    // hue section (using virtual attribute ID at hue attribute ID + 100,000)
+                    attributeType = 'Saturation';
+                    this.map[100000 + attribute.id] = Characteristic[attributeType];
+
+                    if (!this.service.getCharacteristic(Characteristic[attributeType])) {
+                        this.service.addCharacteristic(Characteristic[attributeType]);
+                    }
+
+                    this.service.getCharacteristic(Characteristic[attributeType]).updateValue(attribute.current_value);
+
+                    if (attribute.editable) {
+                        this.service.getCharacteristic(Characteristic[attributeType]).on(
+                            'set',
+                            function() {
+                                var args = Array.prototype.slice.call(arguments);
+                                args.push(100000 + attributeId, attribute.type);
+                                this.setValue.apply(this, args);
+                            }.bind(this)
+                        );
+                    }
+
+                // handling for all other accessory types
+                } else {
+                    this.map[attribute.id] = Characteristic[attributeType];
+
+                    if (!this.service.getCharacteristic(Characteristic[attributeType])) {
+                        this.service.addCharacteristic(Characteristic[attributeType]);
+                    }
+
+                    this.service.getCharacteristic(Characteristic[attributeType]).updateValue(attribute.current_value);
+
+                    if (attribute.editable) {
+                        this.service.getCharacteristic(Characteristic[attributeType]).on(
+                            'set',
+                            function() {
+                                var args = Array.prototype.slice.call(arguments);
+                                args.push(attributeId, attribute.type);
+                                this.setValue.apply(this, args);
+                            }.bind(this)
+                        );
+                    }
                 }
             }
         }
@@ -92,6 +212,25 @@ class HomeeAccessory {
         return [informationService, this.service];
     }
 }
+
+const colorToHSB = (color) => {
+    const r = ((color >> 16) & 0xFF) / 255;
+    const g = ((color >> 8) & 0xFF) / 255;
+    const b = (color & 0xFF) / 255;
+    const v = Math.max(r, g, b),
+          n = v - Math.min(r, g, b);
+    const h = n === 0 ? 0 : n && v === r ? (g - b) / n : v === g ? 2 + (b - r) / n : 4 + (r - g) / n;
+    return [60 * (h < 0 ? h + 6 : h), v && (n / v) * 100, v * 100];
+};
+
+const HSBToColor = (h, s, b) => {
+    s /= 100;
+    b /= 100;
+    const k = (n) => (n + h / 60) % 6;
+    const f = (n) => b * (1 - s * Math.max(0, Math.min(k(n), 4 - k(n), 1)));
+    const color = (Math.round(255 * f(5)) << 16) + (Math.round(255 * f(3)) << 8) + Math.round(255 * f(1));
+    return color;
+};
 
 module.exports = function(oService, oCharacteristic) {
     Service = oService;

--- a/accessories/HomeeAccessory.js
+++ b/accessories/HomeeAccessory.js
@@ -196,6 +196,9 @@ class HomeeAccessory {
 
     // Workaround for HomeKit color picker (does not adjust to color temperature by itself but requires extrenal setting to corresponding color)
     emulateColorTemperature(value, attributeIdHue, attributeIdSaturation) {
+	// Abort if this lightbulb has no hue/saturation characteristics
+	if (this.disableRGB) return;
+
         let rgb = [];
         let colorTemperature = value;
         if (colorTemperature < 1000) colorTemperature = 1000000 / colorTemperature;

--- a/accessories/HomeeAccessory.js
+++ b/accessories/HomeeAccessory.js
@@ -19,6 +19,7 @@ class HomeeAccessory {
             this.hue = 0;            // will be updated with actual value right after service creation 
             this.saturation = 0;     // will be updated with actuel value right after service creation
             this.brightness = 100;   // brightness value currently fixed to 100% for color conversion as setting ignored by homee anyway (except for "dark" color names)
+            // inhibit RGB or color temperature controls for certain lightbulbs
             this.disableRGB = this.platform.disableRGB || this.platform.disableRGBforDevice.indexOf(this.nodeId) >= 0;
             this.disableCT = this.platform.disableCT || this.platform.disableCTforDevice.indexOf(this.nodeId) >= 0;
         }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class HomeePlatform {
         this.connected = false;
         this.groupName = config.groupName || 'homebridge';
         this.alarmGroup = config.alarmGroup || null;
-        // inhibit RGB or color temperature controls for certain lightbulbs
+        // Inhibit RGB or color temperature controls for certain lightbulbs
         this.disableRGB = config.disableRGB || false;
         this.disableCT = config.disableCT || false;
         this.disableCTforRGB = config.disableCTforRGB || false;

--- a/index.js
+++ b/index.js
@@ -41,6 +41,13 @@ class HomeePlatform {
         this.connected = false;
         this.groupName = config.groupName || 'homebridge';
         this.alarmGroup = config.alarmGroup || null;
+        // limitations for RGB or color temperature lightbulbs
+        this.disableRGB = config.disableRGB || false;
+        this.disableCT = config.disableCT || false;
+        this.disableCTforRGB = config.disableCTforRGB || false;
+        this.disableRGBforDevice = config.disableRGBforDevice || [];
+        this.disableCTforDevice = config.disableCTforDevice || [];
+
 
         if (api) this.api = api;
 
@@ -66,7 +73,7 @@ class HomeePlatform {
      * @param callback
      */
     accessories(callback) {
-        if (this.attempts > 10) {
+        if (this.attempts > 50) {   // In extreme cases a very high number of attempts is required (high-load situations and many accessories/homeegrams)
             throw new Error("Can't get devices or homeegrams. Please check that homee is online and your config is ok");
         }
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class HomeePlatform {
         this.connected = false;
         this.groupName = config.groupName || 'homebridge';
         this.alarmGroup = config.alarmGroup || null;
-        // limitations for RGB or color temperature lightbulbs
+        // inhibit RGB or color temperature controls for certain lightbulbs
         this.disableRGB = config.disableRGB || false;
         this.disableCT = config.disableCT || false;
         this.disableCTforRGB = config.disableCTforRGB || false;
@@ -157,7 +157,7 @@ class HomeePlatform {
         if (!groupId) {
             if (this.groupName !== 'homebridge') {
                 throw new Error(
-                    'Specified group not found. Aborting Homebridge startup to prevent lost of accessories'
+                    'Specified group not found. Aborting Homebridge startup to prevent loss of accessories'
                 );
             } else {
                 return [all.nodes, all.homeegrams];

--- a/lib/attribute_types.js
+++ b/lib/attribute_types.js
@@ -9,7 +9,20 @@ exports.getHAPTypeByAttributeType = function(attributeType) {
             HAPType = 'On';
             break;
         case ENUMS.CAAttributeType.CAAttributeTypeDimmingLevel:
+        case ENUMS.CAAttributeType.CAAttributeTypeLEDBrightness:
             HAPType = 'Brightness';
+            break;
+        case ENUMS.CAAttributeType.CAAttributeTypeHue:
+            HAPType = 'Hue';
+            break;
+	    case ENUMS.CAAttributeType.CAAttributeTypeColor:
+            HAPType = 'Color';   // non-existing HAP type used only internally for color lightbulbs (split into hue & saturation)
+            break;
+        case ENUMS.CAAttributeType.CAAttributeTypeSaturation:
+            HAPType = 'Saturation';
+            break;
+        case ENUMS.CAAttributeType.CAAttributeTypeColorTemperature:
+            HAPType = 'ColorTemperature';
             break;
         case ENUMS.CAAttributeType.CAAttributeTypeTemperature:
             HAPType = 'CurrentTemperature';

--- a/lib/attribute_types.js
+++ b/lib/attribute_types.js
@@ -16,7 +16,10 @@ exports.getHAPTypeByAttributeType = function(attributeType) {
             HAPType = 'Hue';
             break;
 	    case ENUMS.CAAttributeType.CAAttributeTypeColor:
-            HAPType = 'Color';   // non-existing HAP type for internal use - intended for RGB lightbulbs (must be split into separate hue & saturation characteristics for HomeKit)
+            HAPType = 'Color';   // Non-existing HAP type, used only internally for color lightbulbs (split into hue & saturation)
+            break;
+        case ENUMS.CAAttributeType.CAAttributeTypeColorMode:
+            HAPType = 'ColorMode';   // Non-existing HAP type used, only internally to filter color and color temperature values sent to HomeKit according to current color mode of accessory
             break;
         case ENUMS.CAAttributeType.CAAttributeTypeSaturation:
             HAPType = 'Saturation';

--- a/lib/attribute_types.js
+++ b/lib/attribute_types.js
@@ -16,7 +16,7 @@ exports.getHAPTypeByAttributeType = function(attributeType) {
             HAPType = 'Hue';
             break;
 	    case ENUMS.CAAttributeType.CAAttributeTypeColor:
-            HAPType = 'Color';   // non-existing HAP type used only internally for color lightbulbs (split into hue & saturation)
+            HAPType = 'Color';   // non-existing HAP type for internal use - intended for RGB lightbulbs (must be split into separate hue & saturation characteristics for HomeKit)
             break;
         case ENUMS.CAAttributeType.CAAttributeTypeSaturation:
             HAPType = 'Saturation';

--- a/sample-config.json
+++ b/sample-config.json
@@ -21,8 +21,7 @@
             "disableCT": false,
             "disableCTforRGB": false,
             "disableRGBforDevice": [
-                123,
-                456
+                123
             ],
             "disableCTforDevice": [
                 666,

--- a/sample-config.json
+++ b/sample-config.json
@@ -16,7 +16,19 @@
             "pass": "your-password",
             "groupName": "homebridge",
             "alarmGroup": "Alarm",
-            "deviceId": "homebridge"
+            "deviceId": "homebridge",
+            "disableRGB" : false,
+            "disableCT" : false,
+            "disableCTforRGB" : false,
+            "disableRGBforDevice" : [
+                123,
+                456
+            ],
+            "disableCTforDevice" : [
+                666,
+                815,
+                4711
+            ]
         }
     ]
 }

--- a/sample-config.json
+++ b/sample-config.json
@@ -17,14 +17,14 @@
             "groupName": "homebridge",
             "alarmGroup": "Alarm",
             "deviceId": "homebridge",
-            "disableRGB" : false,
-            "disableCT" : false,
-            "disableCTforRGB" : false,
-            "disableRGBforDevice" : [
+            "disableRGB": false,
+            "disableCT": false,
+            "disableCTforRGB": false,
+            "disableRGBforDevice": [
                 123,
                 456
             ],
-            "disableCTforDevice" : [
+            "disableCTforDevice": [
                 666,
                 815,
                 4711


### PR DESCRIPTION
This modification to the plugin enables the respective controls in HomeKit to set RGB colors and/or color temperatures for homee devices supporting those features.

The modifications are testing out fine with my Hue Go and Play fixtures connected to the homee Zigbee cube. A flaw in the Home app color picker produces some occasional strange effects (e.g brightness slider displayed in color despite the lightbulb being in CT mode) but this also happens to "real" HomeKit-enabled devices providing both RGB and color temperature. Third-party apps like Eve or Controller do not show this behavior, therefor I'd rather blame Apple for the glitch in their app. Note: In past versions of the HomeKit documentation, simultaneous use of Hue/Saturation and ColorTemprature characteristics in the same lightbulb were prohibited. In the current documentation this limitation does not exist anymore. Hence, I am confident that the implementation in this plugin does not break any rules set by Apple.

If some user do not require RGB color or color temperature controls for specific or even all of their devices, some new configuration options make it is possible to inhibit those controls as desired.